### PR TITLE
Add simple RAG retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This project fine-tunes a Mistral language model on real chat history, hosts it 
 - 📝 Logs all interactions to a local file (`logs.jsonl`)
 - ☁️ Hosted in Colab via Flask + ngrok
 - 🔧 Fully customizable behavior (name-calling requirement, filters, personality)
+- 📚 Retrieval-Augmented Generation (RAG) for knowledge-grounded replies
 
 ---
 
@@ -32,8 +33,12 @@ WhatsApp Trained Bot/
 │   ├── preprocess_chat.py            # Cleans and maps chat exports
 │   └── generate_prompt_responses_multiturn.py  # Builds multi-turn training sets
 │
+├── knowledge/                        # Small text files for RAG context
+│   └── knowledge.txt
 ├── model_hosting/                    # Hosts fine-tuned model using Flask
-│   └── host_model.ipynb
+│   ├── host_model.ipynb
+│   ├── rag_retriever.py              # Simple TF-IDF retriever
+│   └── rag_server.py                 # Example Flask server with RAG
 │
 ├── model_training/                   # Fine-tuning setup for LoRA training
 │   └── train_model.ipynb
@@ -124,18 +129,20 @@ Make sure to **create your own `.env` file** using `.env.example` as a reference
 - Google Colab + GPU
 - Hugging Face account (for loading Mistral base model)
 - Ngrok account (for public URL)
+- `pip install transformers flask flask-cors scikit-learn torch`
 
 ---
 
 ## 📦 To Run the Bot
 
 1. Open `host_model.ipynb` in Colab and run all cells
-2. Copy the ngrok URL
-3. Update `bot.js` with that URL
-4. In `whatsapp-bot/`:
+2. *(Optional)* run `model_hosting/rag_server.py` for RAG-enabled replies
+3. Copy the ngrok URL
+4. Update `bot.js` with that URL
+5. In `whatsapp-bot/`:
    ```bash
    npm start
-5. Scan the QR code with Gurt's WhatsApp account
+6. Scan the QR code with Gurt's WhatsApp account
 
 ---
 

--- a/knowledge/knowledge.txt
+++ b/knowledge/knowledge.txt
@@ -1,0 +1,3 @@
+Gurt is a custom-trained WhatsApp bot built on top of a Mistral language model.
+It can talk in group chats and DMs using the tone of the conversation.
+The bot runs locally via Node.js and communicates with a Flask API that serves the model.

--- a/model_hosting/rag_retriever.py
+++ b/model_hosting/rag_retriever.py
@@ -1,0 +1,32 @@
+import os
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.neighbors import NearestNeighbors
+
+class RAGRetriever:
+    """Simple TF-IDF based retriever."""
+    def __init__(self, knowledge_file="../knowledge/knowledge.txt", top_k=3):
+        self.knowledge_file = os.path.join(os.path.dirname(__file__), knowledge_file)
+        self.top_k = top_k
+        self.docs = self._load_docs()
+        if self.docs:
+            self.vectorizer = TfidfVectorizer(stop_words="english")
+            self.doc_matrix = self.vectorizer.fit_transform(self.docs)
+            self.nbrs = NearestNeighbors(n_neighbors=self.top_k, metric="cosine").fit(self.doc_matrix)
+        else:
+            self.vectorizer = None
+            self.nbrs = None
+
+    def _load_docs(self):
+        if not os.path.exists(self.knowledge_file):
+            return []
+        with open(self.knowledge_file, "r", encoding="utf-8") as f:
+            text = f.read()
+        docs = [p.strip() for p in text.splitlines() if p.strip()]
+        return docs
+
+    def retrieve(self, query):
+        if not self.docs:
+            return []
+        query_vec = self.vectorizer.transform([query])
+        distances, indices = self.nbrs.kneighbors(query_vec, n_neighbors=min(self.top_k, len(self.docs)))
+        return [self.docs[i] for i in indices[0]]

--- a/model_hosting/rag_server.py
+++ b/model_hosting/rag_server.py
@@ -1,0 +1,68 @@
+from flask import Flask, request, jsonify
+from flask_cors import CORS
+from transformers import AutoModelForCausalLM, AutoTokenizer
+import torch
+import regex as re
+
+from rag_retriever import RAGRetriever
+
+# Load a small open model for demonstration
+MODEL_NAME = "gpt2"
+
+print("Loading model...", flush=True)
+tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+model = AutoModelForCausalLM.from_pretrained(MODEL_NAME)
+model.eval()
+
+retriever = RAGRetriever()
+
+app = Flask(__name__)
+CORS(app)
+
+
+def clean_output(text: str) -> str:
+    text = re.sub(r"((\p{Emoji_Presentation}|\p{Extended_Pictographic})\uFE0F?\s?){2,}", lambda m: m.group(0).split()[0] + " ", text)
+    text = re.sub(r"([!?.,])\1{2,}", r"\1", text)
+    text = re.sub(r"([!?.,]){2,}", lambda m: ''.join(set(m.group(0))), text)
+    text = re.sub(r"\b(\w{2,})\b(?:\s+\1\b)+", r"\1", text, flags=re.IGNORECASE)
+    text = re.sub(r"�{2,}", "", text)
+    text = re.sub(r"[^\w\s.,!?🤔😐😂💀🔥☝️🗣️🔊]+$", "", text)
+    return text.strip()
+
+
+@app.route("/generate", methods=["POST"])
+def generate():
+    data = request.json
+    prompt = data.get("prompt", "").strip()
+    if not prompt:
+        return jsonify({"response": ""})
+
+    # Retrieve relevant docs and augment the prompt
+    retrieved = retriever.retrieve(prompt)
+    context = "\n".join(retrieved)
+    final_prompt = f"{context}\n{prompt}\nGurt:"
+
+    inputs = tokenizer(final_prompt, return_tensors="pt")
+    with torch.no_grad():
+        outputs = model.generate(
+            **inputs,
+            max_new_tokens=60,
+            do_sample=True,
+            temperature=0.7,
+            top_p=0.95,
+            pad_token_id=tokenizer.eos_token_id,
+            eos_token_id=tokenizer.eos_token_id,
+        )
+
+    full_output = tokenizer.decode(outputs[0], skip_special_tokens=True)
+    if "Gurt:" in full_output:
+        reply = full_output.split("Gurt:")[-1].strip().split("\n")[0]
+    else:
+        reply = full_output[len(final_prompt):].strip().split("\n")[0]
+
+    reply = clean_output(reply)
+    return jsonify({"response": reply})
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)


### PR DESCRIPTION
## Summary
- add a small knowledge base
- add TF-IDF retriever and Flask server for RAG
- document RAG usage in README

## Testing
- `python - <<'PY'
from model_hosting.rag_retriever import RAGRetriever
r = RAGRetriever()
print(r.retrieve('What is Gurt?'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_686ac91c53f4832f88b0367db114dfc0